### PR TITLE
Fix missing relations

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -73,6 +73,7 @@ class Finder
         $size = $meta['RLF']+$meta['RGF'];
         $meta += unpack($unpack, substr($header, $offset, $size));
 
+        $this->meta['relations'] = array();
         $offset += $size;
         for ($i=0;$i<$meta['RLC'];$i++) {
             $relation = unpack(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no

If I have no relations I have errors
```
PHP Notice:  Undefined index: relations in ...\src\Finder.php on line 191
PHP Warning:  Invalid argument supplied for foreach() in ...\src\Finder.php on line 191
```
